### PR TITLE
FT232R: use native Python time.sleep() on Linux

### DIFF
--- a/drivers/ftdi/dmx_drivers/ftdi/ft232r.py
+++ b/drivers/ftdi/dmx_drivers/ftdi/ft232r.py
@@ -33,6 +33,7 @@
 from os import path
 from platform import system
 from typing import List
+import time
 
 from pylibftdi import Device, Driver, LibraryMissingError
 
@@ -42,36 +43,19 @@ DRIVER_PATH = path.abspath(path.dirname(__file__))
 
 if system() == "Linux":
 
-    from ctypes import cdll, c_long, byref, Structure
-
     Driver._lib_search["libftdi"] = tuple([
         path.join(DRIVER_PATH, "libftdi.so"),
         path.join(DRIVER_PATH, "libftdi.so.1"),
         path.join(DRIVER_PATH, "libftdi1.so")
     ] + list(Driver._lib_search["libftdi"]))
 
-    _LIBC = cdll.LoadLibrary("libc.so.6")
-
-    class timespec(Structure):
-        """A timespec."""
-
-        _fields_ = [("tv_sec", c_long), ("tv_nsec", c_long)]
-
     def wait_ms(milliseconds):
         """Wait for a specified number of milliseconds."""
-        dummy = timespec()
-        sleeper = timespec()
-        sleeper.tv_sec = int(milliseconds / 1000)
-        sleeper.tv_nsec = (milliseconds % 1000) * 1000000
-        _LIBC.nanosleep(byref(sleeper), byref(dummy))
+        time.sleep(milliseconds / 1000)
 
-    def wait_us(nanoseconds):
-        """Wait for a specified number of nanoseconds."""
-        dummy = timespec()
-        sleeper = timespec()
-        sleeper.tv_sec = int(nanoseconds / 1000000)
-        sleeper.tv_nsec = (nanoseconds % 1000) * 1000
-        _LIBC.nanosleep(byref(sleeper), byref(dummy))
+    def wait_us(microseconds):
+        """Wait for a specified number of microseconds."""
+        time.sleep(microseconds / 1000000)
 
 elif system() == "Windows":
 


### PR DESCRIPTION
fixes compatibility with certain libc implementations, e.g. musl on OpenWrt


-------------------------


When trying to use PyDMX with the FTDI driver on an OpenWrt device,
I found it was not outputting any DMX signal, while the same code was working fine on a ubuntu desktop.

As it turned out, there seems to be an issue with the musl implementation of nanosleep as used by OpenWrt,
which made me wonder about the advantage of calling a ctypes function here, rather than using native Python3 sleep().

Regarding performance of the DMX output, I made a few measurements on both desktop and an mt7621-based OpenWrt router, and it did not make any noticeable difference (actually CPython would use usleep or nanosleep anyways, when available), c.f.: https://forum.openwrt.org/t/python3-ctypes-nanosleep-broken-with-musl/216072/11

Could we just change it to use time.sleep() here?
Besides being more Pythonic, at least it made it work on OpenWrt for me :slightly_smiling_face:  

besides, the original code seemed wrong regarding the use of modulo to split the fractional part off the nanoseconds:

in wait_ms there is
```
        sleeper.tv_sec = int(milliseconds / 1000)
        sleeper.tv_nsec = (milliseconds % 1000) * 1000000
```
        
but in wait_us:
```
        sleeper.tv_sec = int(nanoseconds / 1000000)
        sleeper.tv_nsec = (nanoseconds % 1000) * 1000
```

probably should have been
```
        sleeper.tv_nsec = (nanoseconds % 1000000) * 1000
```
instead? For this driver it would not make any difference of course, since sleep is never called with full seconds. 